### PR TITLE
[metrics] add duration gauge

### DIFF
--- a/utils/metrics.ts
+++ b/utils/metrics.ts
@@ -81,6 +81,7 @@ export class Instrumentation {
 			const end = process.hrtime.bigint();
 			const duration = Number(end - start) / 1e6;
 			histogram.record(duration);
+			this.setGauge(`${name}:duration`, duration);
 		}
 	}
 }


### PR DESCRIPTION
add a gauge for duration so we can look at durations over time as simple time series

test plan:
[working](https://metrics.sui.io/goto/d9LZiy_Ig?orgId=1)