### PR TITLE
remove owned increment

### DIFF
--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -13,7 +13,6 @@ export default defineNitroConfig({
 		// Run `cms:update` task every minute
 		'* * * * *': [
 			'execute:simple-transfer',
-			'execute:owned-counter',
 			'execute:shared-counter',
 			'report:balance',
 		],


### PR DESCRIPTION
This likely won't be significantly different than object transfer. Removing for now.